### PR TITLE
fix: mustSpawnEngine does not handle browser env correctly

### DIFF
--- a/src/engine/spawn.ts
+++ b/src/engine/spawn.ts
@@ -67,17 +67,19 @@ const resolveAddr = (resolve: PromiseResolve<string>, line: unknown): void => {
  * If the address cannot be resolved, throws an exception.
  */
 export async function mustSpawnEngine(): Promise<void> {
-  let addr = ''
+  let address: string
+
   if (isWeb()) {
     console.warn(
       `Running in the browser: cannot spawn sidecar with @tauri-apps/api/shell. Make sure engine is running:
       npm run sidecar:exec`
     )
-    addr = import.meta.env.VITE_ENGINE_ADDRESS
+    address = import.meta.env.VITE_ENGINE_ADDRESS
+  } else {
+    address = await spawnEngine()
   }
-  addr = await spawnEngine()
 
-  setAddress(addr)
+  setAddress(address)
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,11 +7,11 @@ import App from './App'
 import { mustSpawnEngine } from './engine/spawn'
 import './index.css'
 
-await mustSpawnEngine()
-
-// eslint-disable-next-line import/no-named-as-default-member
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-)
+mustSpawnEngine().then(() => {
+  // eslint-disable-next-line import/no-named-as-default-member
+  ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  )
+})


### PR DESCRIPTION
## Description

Tauri browser window seems to not support top level await.

## Changes

Replace `await mustSpawnEngine()` with `mustSpawnEngine().then()`

