### PR TITLE
chore : replace px by rem

### DIFF
--- a/src/style/base/globals.scss
+++ b/src/style/base/globals.scss
@@ -1,9 +1,11 @@
 @use '../variables/colors.scss';
 @use '../mixins/font-config.scss';
+@use '../variables//fonts.scss';
 @use 'sass:map';
 
 :root {
-  @include font-config.base-font-config;
+  font-size: fonts.$base-font;
+  line-height: 1.5rem;
   font-family: 'Inter', sans-serif;
   font-weight: 400;
   color: map.get(colors.$colors, 'base-white');

--- a/src/style/variables/fonts.scss
+++ b/src/style/variables/fonts.scss
@@ -1,17 +1,19 @@
+$base-font: 16px;
+
 $font-sizes: (
-  'small': 12.8px,
-  'base': 16px,
-  'h4': 20px,
-  'h3': 25px,
-  'h2': 31.25px,
-  'h1': 39.06px,
+  'small': 0.8rem,
+  'base': 1rem,
+  'h4': 1.25rem,
+  'h3': 1.5625rem,
+  'h2': 1.953125rem,
+  'h1': 2.44125rem,
 );
 
 $line-heights: (
-  'small': 19.2px,
-  'base': 24px,
-  'h4': 24px,
-  'h3': 30px,
-  'h2': 37.5px,
-  'h1': 46.8px,
+  'small': 1.2rem,
+  'base': 1.5rem,
+  'h4': 1.5rem,
+  'h3': 1.875rem,
+  'h2': 2.34375rem,
+  'h1': 2.925rem,
 );


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->
## Description

Replace px by rem in font config

## Linked issues

Closes #32 

## Notes

It introduces some redundancy since I can't use `font-config.base-config` and have to manually set font size and line height
