### PR TITLE
chore(benchttp,engine): update after api changes

### DIFF
--- a/src/benchttp/common.ts
+++ b/src/benchttp/common.ts
@@ -6,8 +6,8 @@ export interface Statistics {
   min: number
   max: number
   mean: number
-  stdDev: number
   median: number
+  standardDeviation: number
   deciles: FixedArray<number, 10> | null
   quartiles: FixedArray<number, 4> | null
 }

--- a/src/benchttp/run.ts
+++ b/src/benchttp/run.ts
@@ -1,7 +1,6 @@
 import { HTTPCode } from '@/typing'
 
 import { Distribution, RequestEvent, Statistics } from './common'
-import { RunConfiguration } from './configuration'
 import { Metric } from './metrics'
 import { TestPredicate } from './tests'
 
@@ -34,7 +33,6 @@ export interface RunReport {
     }[]
   }
   metadata: {
-    config: RunConfiguration
     startedAt: number
     finishedAt: number
   }

--- a/src/engine/stream.ts
+++ b/src/engine/stream.ts
@@ -101,24 +101,9 @@ const startRunStream = async (
   return reader
 }
 
-/**
- * @TODO use a dedicated field from server response for identification.
- */
 const decodeStream = (chunk: Uint8Array): RunStream => {
   const text = new TextDecoder().decode(chunk)
-  const data = JSON.parse(text, function (key: string, value: unknown) {
-    // TODO: remove this block once the engine is updated
-    // and returns only camel-cased JSON.
-    if (!key) return value
-
-    const camelCaseKey = lowerFirstChar(key)
-
-    if (key !== camelCaseKey) {
-      this[camelCaseKey] = value
-      return undefined // unset value for CamelCase key
-    }
-    return value
-  })
+  const data = JSON.parse(text)
   return assertRunStream(data)
 }
 


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Update `benchttp` definitions after changes introduced by https://github.com/benchttp/engine/pull/44.
Also remove the casing conversion in `RunStreamer` which became unnecessary.

<!--
  Describe briefly what this PR does, if the issue description is not enough.
  Add any information that could be relevant for the reviewers.
-->

## Changes

<!--
  List here the collateral changes impacted by this PR, such as
  a notable refactoring, or a breaking change in the API.
-->

## Linked issues

<!--
  List here the issues solved by this PR, with a closing word
  if relevant, e.g. "Closes #12"
 -->

## Notes

<!-- Optional notes -->
