### PR TITLE
ci: upload build assets on manual release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -1,0 +1,62 @@
+name: Build and upload assets to release
+
+on:
+  release:
+    types: [created] # not triggered by draft releases
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: npm
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+
+      - name: Install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - name: Install app dependencies
+        run: npm ci
+
+      - name: Prebuild (ubuntu and macos)
+        if: matrix.platform != 'windows-latest'
+        run: npm run sidecar:build
+
+      - name: Prebuild (windows only)
+        if: matrix.platform == 'windows-latest'
+        run: npm run sidecar:build-windows
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          releaseId: ${{ github.event.release.id }}


### PR DESCRIPTION
## Description

Add a workflow to build and upload the built assets to a release that has been created by human action (typically though GitHub GUI/releases page).

A draft release will **not** trigger the workflow (debatable, we may change that by running on `published` instead of `created`).

The run is : 
```txt
get release tag and id
-> checkout the code at the tag
  -> build the app (same steps as ci.yml)
    -> upload the assets to the release via its id (via tauri-apps/tauri-action@v0)
```

## Linked issues

Closes #53
