### PR TITLE
fix: reset state on start new run

### DIFF
--- a/src/views/Run/Run.tsx
+++ b/src/views/Run/Run.tsx
@@ -8,8 +8,8 @@ import { Configuration, ResultDisplay, Summary } from './internal/components'
 import {
   useRunStream,
   useConfiguration,
-  getTestResultsDisabled,
-  getSummaryDisabled,
+  isTestResultsDisabled,
+  isSummaryDisabled,
 } from './internal/Run.helpers'
 
 export const Run: FC = () => {
@@ -33,7 +33,7 @@ export const Run: FC = () => {
           text="Tests results"
           link="tests-results"
           iconStart={CheckCircle}
-          disabled={getTestResultsDisabled({
+          disabled={isTestResultsDisabled({
             report,
             progress,
             error,
@@ -44,7 +44,7 @@ export const Run: FC = () => {
           text="Summary"
           link="summary"
           iconStart={PieChart}
-          disabled={getSummaryDisabled({ report, error, appError })}
+          disabled={isSummaryDisabled({ report, error, appError })}
         />
       </div>
 

--- a/src/views/Run/Run.tsx
+++ b/src/views/Run/Run.tsx
@@ -44,7 +44,7 @@ export const Run: FC = () => {
           text="Summary"
           link="summary"
           iconStart={PieChart}
-          disabled={isSummaryDisabled({ report, error, appError })}
+          disabled={isSummaryDisabled({ report, progress, error, appError })}
         />
       </div>
 

--- a/src/views/Run/internal/Run.helpers.ts
+++ b/src/views/Run/internal/Run.helpers.ts
@@ -67,7 +67,7 @@ export function useRunStream() {
      * call to start, they will be reset and the run will start over.
      */
     start: (config: RunConfiguration) => {
-      if (!isPristine(state)) {
+      if (hasRunStarted(state)) {
         stream.current.cancel()
         dispatch(['RESET'])
       }
@@ -78,8 +78,8 @@ export function useRunStream() {
   }
 }
 
-const isPristine = (state: RunState): boolean =>
-  state.progress === null || state.report === null || state.error === null
+const hasRunStarted = (state: RunState): boolean =>
+  state.progress !== null || state.report !== null || state.error !== null
 
 export const getTestResultsDisabled = ({
   report,

--- a/src/views/Run/internal/Run.helpers.ts
+++ b/src/views/Run/internal/Run.helpers.ts
@@ -67,7 +67,7 @@ export function useRunStream() {
      * call to start, they will be reset and the run will start over.
      */
     start: (config: RunConfiguration) => {
-      if (hasRunStarted(state)) {
+      if (isStarted(state)) {
         stream.current.cancel()
         dispatch(['RESET'])
       }
@@ -78,33 +78,16 @@ export function useRunStream() {
   }
 }
 
-const hasRunStarted = (state: RunState): boolean =>
-  state.progress !== null || state.report !== null || state.error !== null
+const isStarted = (state: RunState): boolean =>
+  state.progress !== null || isFinished(state)
 
-export const getTestResultsDisabled = ({
-  report,
-  progress,
-  error,
-  appError,
-}: {
-  report: RunReport | null
-  progress: RunProgress | null
-  error: RunError | null
-  appError: Error | null
-}) => {
-  return (
-    report === null && progress === null && error === null && appError === null
-  )
+const isFinished = (state: RunState): boolean =>
+  state.error !== null || state.report !== null
+
+export const isTestResultsDisabled = (state: RunState) => {
+  return !isStarted(state)
 }
 
-export const getSummaryDisabled = ({
-  report,
-  error,
-  appError,
-}: {
-  report: RunReport | null
-  error: RunError | null
-  appError: Error | null
-}) => {
-  return report === null && error === null && appError === null
+export const isSummaryDisabled = (state: RunState) => {
+  return !isFinished(state)
 }


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Fixes an issue where the state of the run was not reset when re-starting it.
Now:

- the state is reset before start if any property of state is non-null
- the `RunStreamer` is reset on start if `ReadableStreamDefaultController is not in a state where it can be closed` error occurs (this is mainly a hack/workaround and not a end solution)

## Changes

<!--
  List here the collateral changes impacted by this PR, such as
  a notable refactoring, or a breaking change in the API.
-->

## Linked issues

<!--
  List here the issues solved by this PR, with a closing word
  if relevant, e.g. "Closes #12"
 -->

## Notes

<!-- Optional notes -->
